### PR TITLE
Match function names  - Fix import/export of data

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,8 +29,8 @@ tree = Tree()
 child = Node('child')
 grand_child = Node('grand child')
 
-tree.add_child(child)
-tree.add_child(grand_child,child)
+tree.add(child)
+tree.add(grand_child,child)
 ```
 
 ## Current functions:

--- a/tests/unit/test_node_movement.py
+++ b/tests/unit/test_node_movement.py
@@ -76,7 +76,7 @@ def test_node_movement():
     tgt_node = tree.find_by_id("9b73a757-da9c-46c0-8ee2-52bd1160ef96")
     new_parent = tree.find_by_id("dbe14fc0-aeef-4745-a4b0-41c98cbbaea8")
 
-    tree.move(tgt_node, new_parent)
+    tree.move_node(tgt_node, new_parent)
 
     assert tgt_node.parent.id == "dbe14fc0-aeef-4745-a4b0-41c98cbbaea8"
     assert len(tree.find_by_id("d7582511-8d32-47d9-a38a-becceb9b88e7").children) == 1

--- a/tree_py/src/lib.rs
+++ b/tree_py/src/lib.rs
@@ -31,7 +31,7 @@ impl TreeWrapper {
         Ok(NodeWrapper(root))
     }
 
-    pub fn add_child(&self, child: NodeWrapper, parent: Option<NodeWrapper>) -> PyResult<()> {
+    pub fn add(&self, child: NodeWrapper, parent: Option<NodeWrapper>) -> PyResult<()> {
         match parent {
             Some(parent_node) => {self.0.lock().unwrap().add_child(child.0, Some(parent_node.0))},
             None => {self.0.lock().unwrap().add_child(child.0, None)}
@@ -90,7 +90,7 @@ fn load_py_tree(py:Python<'_>, obj: &Bound<PyDict>) -> PyResult<Arc<Mutex<Node_r
 
     match obj.get_item("data") {
         Ok(Some(value)) => (DATA_MAP.insert(id.clone(),value.to_object(py))),
-        Ok(None) => (DATA_MAP.insert(id.clone(),py.None())),
+        Ok(None) => None,
         Err(err) => None,
     };
 

--- a/tree_py/src/lib.rs
+++ b/tree_py/src/lib.rs
@@ -141,9 +141,11 @@ struct NodeWrapper(Arc<Mutex<Node_rs>>);
 #[pymethods]
 impl NodeWrapper {
     #[new]
-    fn new (data: PyObject) -> Self {
+    fn new (data: Option<PyObject>) -> Self {
         let node = Node_rs::new(None);
-        DATA_MAP.insert(node.lock().unwrap().id.clone(), data);
+        if let Some(value) = data {
+            DATA_MAP.insert(node.lock().unwrap().id.clone(), value);
+        }
         NodeWrapper(node)
     }
 


### PR DESCRIPTION
- add_child() was misnamed, should have been add()
- in the test, move() should have been named move_node()
- Node wasn't able to be made without data
- Nodes without data were having None exported as data.